### PR TITLE
Fix build with GHC 8.0.2

### DIFF
--- a/src/Control/Concurrent/ForkableT.hs
+++ b/src/Control/Concurrent/ForkableT.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DefaultSignatures, MultiParamTypeClasses, FlexibleContexts, Safe #-}
+{-# LANGUAGE DefaultSignatures, MultiParamTypeClasses, FlexibleContexts, Safe, TypeFamilies #-}
 {-|
   This module defines two classes. @'Forkable' m n@ means a monad @n@ may be forked in @m@.
   @'ForkableT' t@ means that applying the transformer to @n@ and @m@ will mean you can still fork @t n@ in @t m@.
@@ -28,7 +28,8 @@ class ForkableT t where
 -- |Forkable. The default instance uses 'ForkableT' and simply calls 'forkT'
 class (MonadIO m, MonadIO n) => Forkable m n where
     fork :: n () -> m ThreadId
-    default fork :: ForkableT t => t n () -> t m ThreadId
+    default fork :: (ForkableT t, Forkable m' n', n ~ t n', m ~ t m')
+                 => n () -> m ThreadId
     fork = forkT
 
 instance Forkable IO IO where


### PR DESCRIPTION
This package won't build with GHC 8.0.2 due to the typechecker becoming slightly more strict, as observed in [GHC Trac #12784](https://ghc.haskell.org/trac/ghc/ticket/12784). This refactors the default type signature for `Forkable` to fix the 8.0.2 build (while maintaining backwards compatibility).