### PR TITLE
Fix build failure

### DIFF
--- a/src/Control/Concurrent/ForkableT.hs
+++ b/src/Control/Concurrent/ForkableT.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DefaultSignatures, MultiParamTypeClasses, FlexibleContexts, Safe #-}
+{-# LANGUAGE DefaultSignatures, MultiParamTypeClasses, FlexibleContexts, Safe, TypeFamilies #-}
 {-|
   This module defines two classes. @'Forkable' m n@ means a monad @n@ may be forked in @m@.
   @'ForkableT' t@ means that applying the transformer to @n@ and @m@ will mean you can still fork @t n@ in @t m@.
@@ -28,7 +28,7 @@ class ForkableT t where
 -- |Forkable. The default instance uses 'ForkableT' and simply calls 'forkT'
 class (MonadIO m, MonadIO n) => Forkable m n where
     fork :: n () -> m ThreadId
-    default fork :: ForkableT t => t n () -> t m ThreadId
+    default fork :: (m ~ t m', n ~ t n', Forkable m' n', ForkableT t) => t n' () -> t m' ThreadId
     fork = forkT
 
 instance Forkable IO IO where


### PR DESCRIPTION
`ForkableT` [fails to build in `nixpkgs`](http://hydra.nixos.org/build/49162127/nixlog/2) due to the following error:

```
[1 of 2] Compiling Control.Concurrent.ForkableT ( src/Control/Concurrent/ForkableT.hs, dist/build/Control/Concurrent/ForkableT.o )

src/Control/Concurrent/ForkableT.hs:41:10: error:
    • Couldn't match type ‘m’ with ‘ReaderT r m’
      ‘m’ is a rigid type variable bound by
        the instance declaration
        at src/Control/Concurrent/ForkableT.hs:41:10
      Expected type: ReaderT r n () -> ReaderT r m ThreadId
        Actual type: ReaderT r (ReaderT r n) ()
                     -> ReaderT r (ReaderT r m) ThreadId
    • In the expression:
        Control.Concurrent.ForkableT.$dmfork @ReaderT r m @ReaderT r n
      In an equation for ‘fork’:
          fork
            = Control.Concurrent.ForkableT.$dmfork @ReaderT r m @ReaderT r n
      In the instance declaration for
        ‘Forkable (ReaderT r m) (ReaderT r n)’
    • Relevant bindings include
        fork :: ReaderT r n () -> ReaderT r m ThreadId
          (bound at src/Control/Concurrent/ForkableT.hs:41:10)

src/Control/Concurrent/ForkableT.hs:42:10: error:
    • Couldn't match type ‘m’ with ‘StateT s m’
      ‘m’ is a rigid type variable bound by
        the instance declaration
        at src/Control/Concurrent/ForkableT.hs:42:10
      Expected type: StateT s n () -> StateT s m ThreadId
        Actual type: StateT s (StateT s n) ()
                     -> StateT s (StateT s m) ThreadId
    • In the expression:
        Control.Concurrent.ForkableT.$dmfork @StateT s m @StateT s n
      In an equation for ‘fork’:
          fork = Control.Concurrent.ForkableT.$dmfork @StateT s m @StateT s n
      In the instance declaration for
        ‘Forkable (StateT s m) (StateT s n)’
    • Relevant bindings include
        fork :: StateT s n () -> StateT s m ThreadId
          (bound at src/Control/Concurrent/ForkableT.hs:42:10)

src/Control/Concurrent/ForkableT.hs:43:10: error:
    • Couldn't match type ‘m’ with ‘ErrorT e m’
      ‘m’ is a rigid type variable bound by
        the instance declaration
        at src/Control/Concurrent/ForkableT.hs:43:10
      Expected type: ErrorT e n () -> ErrorT e m ThreadId
        Actual type: ErrorT e (ErrorT e n) ()
                     -> ErrorT e (ErrorT e m) ThreadId
    • In the expression:
        Control.Concurrent.ForkableT.$dmfork @ErrorT e m @ErrorT e n
      In an equation for ‘fork’:
          fork = Control.Concurrent.ForkableT.$dmfork @ErrorT e m @ErrorT e n
      In the instance declaration for
        ‘Forkable (ErrorT e m) (ErrorT e n)’
    • Relevant bindings include
        fork :: ErrorT e n () -> ErrorT e m ThreadId
          (bound at src/Control/Concurrent/ForkableT.hs:43:10)
```

This change fixes that build failure